### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo apt-get install python-rpi.gpio python-spidev python-pip python-pil python-
 Install this library by running:
 
 ```
-sudo pip3 install ST7789
+sudo pip3 install Rpi-ST7789
 ```
 
 # Licensing & History


### PR DESCRIPTION
pip3 install ST7789 installs the original https://github.com/pimoroni/st7789-python library. You must use pip3 install Rpi-ST7789 to have support for mode=3 allowing displays with no CS pin to work